### PR TITLE
Make sure NEOS builds with matched kernel

### DIFF
--- a/devices/eon/README.md
+++ b/devices/eon/README.md
@@ -6,6 +6,7 @@ from your PATH if necessary.
 
 # Options
 - If you want to increase the version number, that is in `build_ramdisk_boot.sh`.
+- If the msm8996 kernel has changed, change the commit hash in `make_x_image.sh`.
 - If you want the dashcam branch to be pre-checked-out in the image set `EMBED_DASHCAM=1`
 
 # Normal build procedure

--- a/devices/eon/make_x_image.sh
+++ b/devices/eon/make_x_image.sh
@@ -15,11 +15,12 @@ $TOOLS/extract_toolchains.sh
 mkdir -p $OUT
 
 if [ ! -d android_kernel_comma_msm8996 ]; then
-  git clone https://github.com/commaai/android_kernel_comma_msm8996.git --depth 1
+  git clone https://github.com/commaai/android_kernel_comma_msm8996.git --depth 50
 fi
 
 # Compile kernel
 cd android_kernel_comma_msm8996
+git checkout d2918fd9489da0eeda32ff7e465a28b0e0b94b5f
 git pull
 make comma_defconfig
 make -j$(nproc --all)


### PR DESCRIPTION
Previously the NEOS build scripts just check out `master` from android_kernel_comma_msm8996. Going forward, it's important to match the NEOS kernel and Android userland versions.