### PR TITLE
Repeatable build fixes

### DIFF
--- a/devices/eon/.gitignore
+++ b/devices/eon/.gitignore
@@ -2,7 +2,6 @@ android_kernel_comma_msm8996/
 mindroid/
 mnt/
 out/
-ota/
 usr/
 venv/
 ramdisk-boot.gz

--- a/devices/eon/.gitignore
+++ b/devices/eon/.gitignore
@@ -2,6 +2,7 @@ android_kernel_comma_msm8996/
 mindroid/
 mnt/
 out/
+ota/
 usr/
 venv/
 ramdisk-boot.gz

--- a/devices/eon/README.md
+++ b/devices/eon/README.md
@@ -5,12 +5,11 @@ either directly or using `pyenv` to override. Remove the `pyenv` entries
 from your PATH if necessary.
 
 # Important notes
-- If you want to increase the version number, that is in `build_ramdisk_boot.sh`.
+- If you want to increase the version number, that is in `build_env.sh`.
 - If the msm8996 kernel has changed, change the commit hash in `make_x_image.sh`.
 - If making changes to Android components, check `build_system.sh` for where to
   check out the `mindroid` branch of the Android build manifest. When finished
   with testing, update the commit hashes in `repeatable-build-mindroid`.
-- If you want the dashcam branch to be pre-checked-out in the image set `EMBED_DASHCAM=1`
 
 # Normal build procedure
 1. If not already done, set some Git config parameters:
@@ -34,3 +33,11 @@ This process requires an EON connected with [Comma Smays](https://comma.ai/shop/
 2. Copy `neosupdate/update.staging.json` into openpilot `installer/updater/update.json`
 3. Update the NEOS version check in `launch_chffrplus.sh`.
 4. When going to production run `./ota_push_prod.sh`, and put `neosupdate/update.json` in the updater folder.
+
+# Comma internal only: updating an existing NEOS image with current dashcam-staging
+
+1. Ensure the openpilot repo dashcam-staging branch is up-to-date and has the desired base `installer/updater/update.json`
+2. Fetch the current NEOS and re-roll the system partition with the current dashcam version slipstreamed: `./build_dashcam_images.sh`
+3. Run `./prepare_ota.sh` to generate new signed OTA update images.
+4. Run `./ota_push_prod.sh` to upload to Azure.
+5. Replace `update.json` in the eon-neos repository with `neosupdate/update.json`.

--- a/devices/eon/README.md
+++ b/devices/eon/README.md
@@ -4,9 +4,12 @@ Make sure the system default Python 2 has not been replaced with Python 3,
 either directly or using `pyenv` to override. Remove the `pyenv` entries
 from your PATH if necessary.
 
-# Options
+# Important notes
 - If you want to increase the version number, that is in `build_ramdisk_boot.sh`.
 - If the msm8996 kernel has changed, change the commit hash in `make_x_image.sh`.
+- If making changes to Android components, check `build_system.sh` for where to
+  check out the `mindroid` branch of the Android build manifest. When finished
+  with testing, update the commit hashes in `repeatable-build-mindroid`.
 - If you want the dashcam branch to be pre-checked-out in the image set `EMBED_DASHCAM=1`
 
 # Normal build procedure

--- a/devices/eon/build_android.sh
+++ b/devices/eon/build_android.sh
@@ -20,7 +20,12 @@ fi
 # build mindroid
 mkdir -p $DIR/mindroid/system
 cd $DIR/mindroid/system
-$TOOLS/repo init -u https://github.com/commaai/android.git -b mindroid
+
+# By default, check out the "repeatable-build-mindroid" manifest with locked
+# hashes for each Comma-forked component. If doing active development, check
+# out "mindroid" instead, update the repeatable-build-mindroid manifest hashes
+# when finished, and update the commit hash here.
+$TOOLS/repo init -u https://github.com/commaai/android.git -b aa44fb6fe6291f5a22e033cf0486fe07dce81db6
 $TOOLS/repo sync -c -j$JOBS
 
 export PATH=$PWD/bin:$PATH

--- a/devices/eon/build_dashcam_images.sh
+++ b/devices/eon/build_dashcam_images.sh
@@ -14,18 +14,19 @@ cd $DIR
 
 echo "Extracting and updating original NEOS base image" && echo
 sudo umount $OUT/mnt || true
-rm -rf $OUT $OTA
-mkdir -p $OUT/mnt $OUT/tmp $OTA
+rm -rf $OUT/ota_tmp
+mkdir -p $OUT/mnt $OUT/ota_tmp $OTA
 
-unzip build_usr/ota-signed-latest.zip -d $OTA
-sudo mount -o loop $OTA/files/system.img $OUT/mnt
+# Unzip ota image and copy to out folder
+unzip build_usr/ota-signed-latest.zip -d $OUT/ota_tmp
+cp $OUT/ota_tmp/files/boot.img $OUT/boot.img
+cp $OUT/ota_tmp/files/system.img $OUT/system.img
 
+# Mount system.img and check out new dashcam-staging
+sudo mount -o loop $OUT/system.img $OUT/mnt
 sudo rm -rf $OUT/mnt/comma/openpilot
 sudo git clone --branch=dashcam-staging --depth=1 https://github.com/commaai/openpilot.git $OUT/mnt/comma/openpilot
-
 sudo umount $OUT/mnt
 
-# Staging for existing local flash and OTA prep scripts to function
+# Copy recovery.img from revious release
 cp build_usr/recovery.img $DIR/out/recovery.img
-ln ota/files/boot.img out/boot.img
-ln ota/files/system.img out/system.img

--- a/devices/eon/build_dashcam_images.sh
+++ b/devices/eon/build_dashcam_images.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+OUT=$DIR/out
+OTA=$DIR/ota
+
+cd $DIR
+source build_env.sh
+
+echo "Downloading existing NEOS OTA images from current dashcam branch" && echo
+cd build_usr
+./download.py
+cd $DIR
+
+echo "Extracting and updating original NEOS base image" && echo
+sudo umount $OUT/mnt || true
+rm -rf $OUT $OTA
+mkdir -p $OUT/mnt $OUT/tmp $OTA
+
+unzip build_usr/ota-signed-latest.zip -d $OTA
+sudo mount -o loop $OTA/files/system.img $OUT/mnt
+
+sudo rm -rf $OUT/mnt/comma/openpilot
+sudo git clone --branch=dashcam-staging --depth=1 https://github.com/commaai/openpilot.git $OUT/mnt/comma/openpilot
+
+sudo umount $OUT/mnt
+
+# Staging for existing local flash and OTA prep scripts to function
+cp build_usr/recovery.img $DIR/out/recovery.img
+ln ota/files/boot.img out/boot.img
+ln ota/files/system.img out/system.img

--- a/devices/eon/build_dashcam_images.sh
+++ b/devices/eon/build_dashcam_images.sh
@@ -7,9 +7,9 @@ OTA=$DIR/ota
 cd $DIR
 source build_env.sh
 
-echo "Downloading existing NEOS OTA images from current dashcam branch" && echo
-cd build_usr
-./download.py
+mkdir -p $OUT/download
+cd $OUT/download
+$DIR/build_usr/download.py
 cd $DIR
 
 echo "Extracting and updating original NEOS base image" && echo
@@ -18,7 +18,7 @@ rm -rf $OUT/ota_tmp
 mkdir -p $OUT/mnt $OUT/ota_tmp $OTA
 
 # Unzip ota image and copy to out folder
-unzip build_usr/ota-signed-latest.zip -d $OUT/ota_tmp
+unzip $OUT/download/ota-signed-latest.zip -d $OUT/ota_tmp
 cp $OUT/ota_tmp/files/boot.img $OUT/boot.img
 cp $OUT/ota_tmp/files/system.img $OUT/system.img
 
@@ -28,5 +28,5 @@ sudo rm -rf $OUT/mnt/comma/openpilot
 sudo git clone --branch=dashcam-staging --depth=1 https://github.com/commaai/openpilot.git $OUT/mnt/comma/openpilot
 sudo umount $OUT/mnt
 
-# Copy recovery.img from revious release
-cp build_usr/recovery.img $DIR/out/recovery.img
+# Copy recovery.img from previous release
+cp $OUT/download/recovery.img $DIR/out/recovery.img

--- a/devices/eon/build_env.sh
+++ b/devices/eon/build_env.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# NEOS_VERSION sets the /VERSION for the new build. This value MUST be updated
+# for any change put into test/staging or production. For interim builds, use 
+# a value like "15-RC3" or similar, so that any device with a test build will
+# update to the final release version.
+
+export NEOS_BUILD_VERSION="14"
+
+# NEOS_BASE_FOR_USR sets the OTA image used for normal NEOS builds, where the
+# Termux /system base binaries are copied from the production shipping OTA
+# image instead of rebuilding from scratch. Ignored if CLEAN_USR=1.
+
+export NEOS_BASE_FOR_USR="https://raw.githubusercontent.com/commaai/eon-neos/d22cfd2123e13fded340e6290eea8204c73ce9a2/update.json"
+
+# NEOS_BASE_FOR_DASHCAM is used by build_dashcam_images.sh to set the base OTA
+# image on which to build a dashcam-cached system image. These images are used
+# in the Comma manufacturing process and also for PC desktop flashing. Before
+# and after NEOS versions must match.
+
+export NEOS_BASE_FOR_DASHCAM="https://raw.githubusercontent.com/commaai/openpilot/dashcam-staging/installer/updater/update.json"

--- a/devices/eon/build_env.sh
+++ b/devices/eon/build_env.sh
@@ -14,9 +14,11 @@ export NEOS_BUILD_VERSION="14"
 export NEOS_BASE_FOR_USR="https://raw.githubusercontent.com/commaai/eon-neos/d22cfd2123e13fded340e6290eea8204c73ce9a2/update.json"
 
 
-# TODO: this url can't be used now since it doesn't include the focaltech touchscreen fix in the kernel
 # NEOS_BASE_FOR_DASHCAM is used by build_dashcam_images.sh to set the base OTA
 # image on which to build a dashcam-cached system image. These images are used
 # in the Comma manufacturing process and also for PC desktop flashing. Before
 # and after NEOS versions must match.
+
+# TODO: this url can't be used for NEOS 14 because it's missing the focaltech touchscreen fix in the kernel
 # export NEOS_BASE_FOR_DASHCAM="https://raw.githubusercontent.com/commaai/openpilot/dashcam-staging/installer/updater/update.json"
+export NEOS_BASE_FOR_DASHCAM="$NEOS_BASE_FOR_USR"

--- a/devices/eon/build_env.sh
+++ b/devices/eon/build_env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # NEOS_VERSION sets the /VERSION for the new build. This value MUST be updated
-# for any change put into test/staging or production. For interim builds, use 
+# for any change put into test/staging or production. For interim builds, use
 # a value like "15-RC3" or similar, so that any device with a test build will
 # update to the final release version.
 
@@ -13,9 +13,10 @@ export NEOS_BUILD_VERSION="14"
 
 export NEOS_BASE_FOR_USR="https://raw.githubusercontent.com/commaai/eon-neos/d22cfd2123e13fded340e6290eea8204c73ce9a2/update.json"
 
+
+# TODO: this url can't be used now since it doesn't include the focaltech touchscreen fix in the kernel
 # NEOS_BASE_FOR_DASHCAM is used by build_dashcam_images.sh to set the base OTA
 # image on which to build a dashcam-cached system image. These images are used
 # in the Comma manufacturing process and also for PC desktop flashing. Before
 # and after NEOS versions must match.
-
-export NEOS_BASE_FOR_DASHCAM="https://raw.githubusercontent.com/commaai/openpilot/dashcam-staging/installer/updater/update.json"
+# export NEOS_BASE_FOR_DASHCAM="https://raw.githubusercontent.com/commaai/openpilot/dashcam-staging/installer/updater/update.json"

--- a/devices/eon/build_ramdisk_boot.sh
+++ b/devices/eon/build_ramdisk_boot.sh
@@ -2,6 +2,7 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd "$DIR"
+source build_env.sh
 
 BOOT_RAMDISK="mindroid/system/out/target/product/oneplus3/ramdisk.img"
 [ ! -f $BOOT_RAMDISK ] && ./build_android.sh
@@ -21,7 +22,7 @@ pushd boot_ramdisk
   ln -s /data/data/com.termux/files/tmp tmp
   ln -s /data/data/com.termux/files/usr usr
   sudo cp -v "$DIR"/ramdisk_common/* .
-  echo "14" > VERSION
+  echo "$NEOS_BUILD_VERSION" > VERSION
   touch EON
 
   # repack ramdisk

--- a/devices/eon/build_system.sh
+++ b/devices/eon/build_system.sh
@@ -36,12 +36,13 @@ sudo mkdir -p mnt/comma
 sudo cp -R ../build_usr/out/data/data/com.termux/files/usr mnt/comma
 
 sudo chmod a+rx mnt/comma mnt/comma/usr mnt/comma/usr/lib
-if [ -z "$EMBED_DASHCAM" ]; then
-    echo "Skipping dashcam checkout"
-else
-    sudo rm -rf mnt/comma/openpilot
-    sudo git clone --branch=dashcam-staging --depth=1 https://github.com/commaai/openpilot.git mnt/comma/openpilot
-fi
+# base build option for embedding dashcam is deprecated in favor of build-dashcam-images.sh
+#if [ -z "$EMBED_DASHCAM" ]; then
+#    echo "Skipping dashcam checkout"
+#else
+#    sudo rm -rf mnt/comma/openpilot
+#    sudo git clone --branch=dashcam-staging --depth=1 https://github.com/commaai/openpilot.git mnt/comma/openpilot
+#fi
 
 sudo sed -i 's/ro.adb.secure=1/ro.adb.secure=0/' mnt/build.prop
 sudo sed -i 's/neos.vpn=1/neos.vpn=0/' mnt/build.prop

--- a/devices/eon/build_usr/download.py
+++ b/devices/eon/build_usr/download.py
@@ -29,9 +29,10 @@ def download(url, fhash, finalname):
 
 if __name__ == "__main__":
   try:
-    # For Comma internal builds, prefer locally defined NEOS image URLs
-    up = json.loads(open('/home/batman/openpilot/installer/updater/update.json').read())
+    ota_json_download_url = os.getenv("NEOS_BASE_FOR_USR")
+    up = requests.get(ota_json_download_url).json()
   except Exception:
-    # For external builds, use the public NEOS image URLs
-    up = requests.get("https://raw.githubusercontent.com/commaai/eon-neos/master/update.json").json()
+    print("Couldn't fetch current NEOS OTA image!")
+    raise
   download(up['ota_url'], up['ota_hash'], "ota-signed-latest.zip")
+  download(up['recovery_url'], up['recovery_hash'], "recovery.img")

--- a/devices/eon/build_usr/download.py
+++ b/devices/eon/build_usr/download.py
@@ -29,7 +29,12 @@ def download(url, fhash, finalname):
 
 if __name__ == "__main__":
   try:
-    ota_json_download_url = os.getenv("NEOS_BASE_FOR_USR")
+    if os.getenv("CLEAN_USR") == "1":
+      ota_json_download_url = os.getenv("NEOS_BASE_FOR_USR")
+      print("Fetching NEOS base for /usr from system image")
+    else:
+      ota_json_download_url = os.getenv("NEOS_BASE_FOR_DASHCAM")
+      print("Fetching NEOS base for dashcam slipstream")
     up = requests.get(ota_json_download_url).json()
   except Exception:
     print("Couldn't fetch current NEOS OTA image!")


### PR DESCRIPTION
Now that the kernel is checked out with a particular commit hash, do the same for the Comma modified Android components. This should ensure that eon-neos-builder, checked out from any given point in its commit history, can reproduce the same complete build.