### PR TITLE
Fixes for building on Ubuntu 20.04

### DIFF
--- a/devices/eon/build_android.sh
+++ b/devices/eon/build_android.sh
@@ -34,3 +34,4 @@ $TOOLS/repo sync -c -j$JOBS
 
 export PATH=$PWD/bin:$PATH
 (source build/envsetup.sh && breakfast oneplus3 && make -j$JOBS)
+

--- a/devices/eon/build_android.sh
+++ b/devices/eon/build_android.sh
@@ -7,6 +7,9 @@ TOOLS=$ROOT/tools
 cd $DIR
 source build_env.sh
 
+# Override locale to prevent assert on LC_TIME sizeof later in build process
+export LC_ALL=C
+
 # install build tools
 if [[ ! -z "${INSTALL_DEPS}" ]]; then
   source $DIR/install_deps.sh

--- a/devices/eon/install_deps.sh
+++ b/devices/eon/install_deps.sh
@@ -15,6 +15,16 @@ echo "Starting dependency installs"
 sudo apt-get update || true
 sudo apt-get install -y cpio git git-lfs gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc unzip python3-requests bc android-sdk-libsparse-utils android-sdk-ext4-utils openjdk-8-jdk openjdk-8-jre android-sdk nodejs yarn
 
+# Check to make sure java/javac are set to use JRE/JDK version 8, required by Android SDK
+JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\.//' | cut -d'.' -f1)
+JAVAC_VERSION=$(javac -version 2>&1 | head -1 | cut -d' ' -f2 | sed 's/^1\.//' | cut -d'.' -f1)
+echo "java version: ${JAVA_VERSION}"
+echo "javac version: ${JAVAC_VERSION}"
+if [ $JAVA_VERSION != "8" ] || [ $JAVAC_VERSION != "8" ]; then
+  echo "java / javac version 8 must be selected with \"sudo update-alternatives --config [java/javac]\" before proceeding"
+  exit
+fi
+
 # Additional setup for Android SDK environment and toolset
 if [[ ! -f "/usr/lib/android-sdk/tools/bin/sdkmanager" ]]; then
   echo "Installing Android SDK tools"

--- a/devices/eon/install_deps.sh
+++ b/devices/eon/install_deps.sh
@@ -2,18 +2,13 @@
 
 echo "Starting dependency installs"
 
-# Add third-party package repos and keys required for Ubuntu 16.04
-# sudo apt-get install curl
-# git-lfs
-#curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
-# nodejs and yarn (versions in Ubuntu repo are old/broken)
-#curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-#curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-#echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-
 # Basic dependencies
 sudo apt-get update || true
-sudo apt-get install -y cpio git git-lfs gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc unzip python3-requests bc android-sdk-libsparse-utils android-sdk-ext4-utils openjdk-8-jdk openjdk-8-jre android-sdk nodejs yarn
+sudo apt-get install -y cpio git git-lfs gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc unzip python3-requests bc android-sdk-libsparse-utils android-sdk-ext4-utils openjdk-8-jdk openjdk-8-jre android-sdk yarnpkg nodejs
+
+# Clean up if the cmdtest version of yarn is already installed, then make sure yarnpkg is the system default yarn
+sudo apt-get remove -y cmdtest || true
+[[ ! -h "/usr/bin/yarn" ]] && sudo ln -s /usr/bin/yarnpkg /usr/bin/yarn
 
 # Check to make sure java/javac are set to use JRE/JDK version 8, required by Android SDK
 JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\.//' | cut -d'.' -f1)

--- a/devices/eon/install_deps.sh
+++ b/devices/eon/install_deps.sh
@@ -4,7 +4,7 @@ echo "Starting dependency installs"
 
 # Basic dependencies
 sudo apt-get update || true
-sudo apt-get install -y cpio git git-lfs gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc unzip python3-requests bc android-sdk-libsparse-utils android-sdk-ext4-utils openjdk-8-jdk openjdk-8-jre android-sdk yarnpkg nodejs
+sudo apt-get install -y cpio git git-lfs gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 libncurses5 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc unzip python3-requests bc android-sdk-libsparse-utils android-sdk-ext4-utils openjdk-8-jdk openjdk-8-jre android-sdk yarnpkg nodejs
 
 # Clean up if the cmdtest version of yarn is already installed, then make sure yarnpkg is the system default yarn
 sudo apt-get remove -y cmdtest || true

--- a/devices/eon/install_deps.sh
+++ b/devices/eon/install_deps.sh
@@ -13,7 +13,7 @@ echo "Starting dependency installs"
 
 # Basic dependencies
 sudo apt-get update || true
-sudo apt-get install -y cpio git-core git-lfs gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc unzip python python-requests bc android-tools-fsutils openjdk-8-jdk openjdk-8-jre android-sdk nodejs yarn
+sudo apt-get install -y cpio git git-lfs gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc unzip python3-requests bc android-sdk-libsparse-utils android-sdk-ext4-utils openjdk-8-jdk openjdk-8-jre android-sdk nodejs yarn
 
 # Additional setup for Android SDK environment and toolset
 if [[ ! -f "/usr/lib/android-sdk/tools/bin/sdkmanager" ]]; then


### PR DESCRIPTION
Make NEOS build on a fresh Ubuntu 20.04 install with nothing but current updates. Mostly changes to `install_deps.sh` to trade out some deprecated packages in favor of new ones we need, and better handling of the tangled Yarn and Java situations.